### PR TITLE
Fixed `PrintingTime` reading from latest `OrcaSlicer`

### DIFF
--- a/src/GcodeParser.Test/GcodeParser.Test.csproj
+++ b/src/GcodeParser.Test/GcodeParser.Test.csproj
@@ -51,6 +51,9 @@
     <None Update="Gcodes\Simplify3D.gcode">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Gcodes\OrcaSlicer_Beta.gcode">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/GcodeParser.Test/UnitTest.cs
+++ b/src/GcodeParser.Test/UnitTest.cs
@@ -7,6 +7,7 @@ namespace GcodeSharpParser.Test
     {
         public List<string> testfiles = new()
         {
+            @"Gcodes\OrcaSlicer_Beta.gcode",
             @"Gcodes\BambuStudio.gcode",
             @"Gcodes\PrusaSlicer2.gcode",
             @"Gcodes\OrcaSlicer.gcode",

--- a/src/GcodeParserSharp/Enums/SlicerParameter.cs
+++ b/src/GcodeParserSharp/Enums/SlicerParameter.cs
@@ -7,6 +7,7 @@
         PrintTimeSilent,
         PrintTimeModel,
         FilamentUsed,
+        FilamentWeight,
         FilamentDiameter,
         FilamentType,
         FilamentDensity,

--- a/src/GcodeParserSharp/GcodeParser.Regex.cs
+++ b/src/GcodeParserSharp/GcodeParser.Regex.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.RegularExpressions;
+
+namespace AndreasReitberger.Parser.Gcode
+{
+    public partial class GcodeParser
+    {
+        #region Recurring Regex Pattern
+
+        public static string FilamentVolumePattern => @"[;]\s*filament used\s*\[cm3\]\s*=\s*\d*.\d*";
+        public static string FilamentLengthPattern => @"[;]\s*filament used\s*\[mm\]\s*=\s*\d*.\d*";
+        public static string FilamentWeightPattern => @"[;]\s*filament used\s*\[mm\]\s*=\s*\d*.\d*";
+        public static string PrintingTimePattern => @"([;]\s*(total estimated time)|(estimated printing time)\s*=*)";
+        #endregion
+
+        #region Regex
+        public static Regex FilamentVolume => new(FilamentVolumePattern);
+        public static Regex FilamentLength => new(FilamentLengthPattern);
+        public static Regex FilamentWeight => new(FilamentWeightPattern);
+        public static Regex PrintingTime => new(PrintingTimePattern);
+
+        #endregion
+    }
+}

--- a/src/GcodeParserSharp/GcodeParser.cs
+++ b/src/GcodeParserSharp/GcodeParser.cs
@@ -1287,11 +1287,13 @@ namespace AndreasReitberger.Parser.Gcode
                         switch (Parameter)
                         {
                             case SlicerParameter.Volume:
-                                myregex = new Regex(@"[;]\s*filament used\s*\[cm3\]\s*=\s*\d*.\d*");
+                                //myregex = new Regex(@"[;]\s*filament used\s*\[cm3\]\s*=\s*\d*.\d*");
+                                myregex = FilamentVolume;
                                 lines = Lines.Where(line => !string.IsNullOrEmpty(line) && myregex.IsMatch(line)).ToList();
                                 return Regex.Match(lines[0], @"(\s\d*.\d{1,2})").Groups[1].Value;
                             case SlicerParameter.FilamentUsed:
-                                myregex = new Regex(@"[;]\s*filament used\s*\[mm\]\s*=\s*\d*.\d*");
+                                //myregex = new Regex(@"[;]\s*filament used\s*\[mm\]\s*=\s*\d*.\d*");
+                                myregex = FilamentLength;
                                 lines = Lines.Where(line => !string.IsNullOrEmpty(line) && myregex.IsMatch(line)).ToList();
                                 return Regex.Match(lines[0], @"(\s\d*.\d{1,2})").Groups[1].Value;
                             case SlicerParameter.PrintTime:
@@ -1326,7 +1328,8 @@ namespace AndreasReitberger.Parser.Gcode
                         switch (Parameter)
                         {
                             case SlicerParameter.Volume:
-                                myregex = new Regex(@"[;]\s*filament used\s*\[cm3\]\s*=\s*\d*.\d*");
+                                //myregex = new Regex(@"[;]\s*filament used\s*\[cm3\]\s*=\s*\d*.\d*");
+                                myregex = FilamentVolume;
                                 lines = Lines.Where(line => !string.IsNullOrEmpty(line) && myregex.IsMatch(line)).ToList();
                                 string vol = ConcatNumericDataString(
                                     lines.FirstOrDefault()?.Replace("; filament used [cm3] = ", string.Empty), ",",
@@ -1335,12 +1338,19 @@ namespace AndreasReitberger.Parser.Gcode
                                 return vol;
                                 //return Regex.Match(lines[0], @"(\s\d*.\d{1,2})").Groups[1].Value;
                             case SlicerParameter.FilamentUsed:
-                                myregex = new Regex(@"[;]\s*filament used\s*\[mm\]\s*=\s*\d*.\d*");
+                                //myregex = new Regex(@"[;]\s*filament used\s*\[mm\]\s*=\s*\d*.\d*");
+                                myregex = FilamentLength;
+                                lines = Lines.Where(line => !string.IsNullOrEmpty(line) && myregex.IsMatch(line)).ToList();
+                                return Regex.Match(lines[0], @"(\s\d*.\d{1,2})").Groups[1].Value;
+                            case SlicerParameter.FilamentWeight:
+                                //myregex = new Regex(@"[;]\s*filament used\s*\[g\]\s*=\s*\d*.\d*");
+                                myregex = FilamentWeight;
                                 lines = Lines.Where(line => !string.IsNullOrEmpty(line) && myregex.IsMatch(line)).ToList();
                                 return Regex.Match(lines[0], @"(\s\d*.\d{1,2})").Groups[1].Value;
                             case SlicerParameter.PrintTime:
-                                //myregex = new Regex(@"[;]\s*estimated printing time \(normal mode\)\s*=\s*\d*h\s*\d*m\s*\d*s");
-                                myregex = new Regex(@"[;]\s*total estimated time\s*=*");
+                                //myregex = new Regex(@"[;]\s*total estimated time\s*=*");
+                                //myregex = new Regex(@"([;]\s*(total estimated time)|(estimated printing time)\s*=*)");
+                                myregex = PrintingTime;
                                 lines = Lines.Where(line => !string.IsNullOrEmpty(line) && myregex.IsMatch(line)).ToList();
                                 // Result looks like, we need the second paramater "; model printing time: 8m 6s; total estimated time: 15m 26s"
                                 string targetTotalPrintTime = lines.FirstOrDefault()?.Split(new string[] { ";" }, StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.Trim();
@@ -1393,7 +1403,8 @@ namespace AndreasReitberger.Parser.Gcode
                             */
                             case SlicerParameter.PrintTime:
                                 //myregex = new Regex(@"[;]\s*estimated printing time \(normal mode\)\s*=\s*\d*h\s*\d*m\s*\d*s");
-                                myregex = new Regex(@"[;]\s*total estimated time\s*=*");
+                                //myregex = new Regex(@"[;]\s*total estimated time\s*=*");
+                                myregex = PrintingTime;
                                 lines = Lines.Where(line => !string.IsNullOrEmpty(line) && myregex.IsMatch(line)).ToList();
                                 // Result looks like, we need the second paramater "; model printing time: 8m 6s; total estimated time: 15m 26s"
                                 string targetTotalPrintTime = lines.FirstOrDefault()?.Split(new string[] { ";" }, StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.Trim();


### PR DESCRIPTION
This PR fixes a bug which lead to a 0h printing time if the latest `OrcaSlicer` beta version is used.

Fixed #37